### PR TITLE
bump low level dependencies to current main releases

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,6 +17,7 @@ supports 'ubuntu', '>= 12.04'
 supports 'windows'
 supports 'mac_os_x'
 
-depends 'apt', '~> 2.0'
+depends 'apt', '~> 4.0'
 depends 'yum', '~> 3.0'
-depends 'windows', '~> 1.0'
+
+chef_version '>= 12.6'


### PR DESCRIPTION
apt ~> 4.0
yum ~> 3.0
windows ~> 2.0

These dependencies are woefully out of date and creating havoc on convergence right now.
