### PR TITLE
Updating cookbook to support new cli package name

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,7 @@ platforms:
   - name: centos-7.1
   - name: ubuntu-12.04
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: debian-7.9
   - name: windows-2012r2
     driver:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,7 +12,7 @@ when 'rhel', 'fedora'
     action :create
   end
 
-  package 'perforce-cli'
+  package 'helix-cli'
 when 'debian'
   dist = case major_version # http://askubuntu.com/a/445496
          when '12', '13', '7'
@@ -30,7 +30,7 @@ when 'debian'
     key 'https://package.perforce.com/perforce.pubkey'
   end
 
-  package 'perforce-cli'
+  package 'helix-cli'
 when 'windows'
   bit = node['kernel']['machine'] == 'x86_64' ? 'x64' : 'x86'
 

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -15,7 +15,7 @@ describe 'perforce::default' do
     end
 
     it 'installs p4 cli package' do
-      expect(chef_run).to install_package('perforce-cli')
+      expect(chef_run).to install_package('helix-cli')
     end
   end
 
@@ -31,7 +31,7 @@ describe 'perforce::default' do
     end
 
     it 'installs p4 command-line client package' do
-      expect(chef_run).to install_package('perforce-cli')
+      expect(chef_run).to install_package('helix-cli')
     end
   end
 


### PR DESCRIPTION
Perforce is currently in the process of changing from perforce-cli to helix-cli. The current iteration of _perforce-cli_ is a transition package. _helix-cli_ exists for all the debian and rhel based distros and is the suggested package to use going forward.