### PR TITLE
Update p4 release version to r18.1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
 default['perforce']['download_url'] = 'http://www.perforce.com/downloads/perforce'
-default['perforce']['release'] = 'r16.1'
+default['perforce']['release'] = 'r18.1'


### PR DESCRIPTION
Update p4 release version to r18.1. 
Version r16.1 is no longer available for download on P4 filehost server causing this cookbook to fail.